### PR TITLE
Arrival time of previous connection greater or equal previous arrival…

### DIFF
--- a/lib/BasicCSA.js
+++ b/lib/BasicCSA.js
@@ -101,7 +101,7 @@ ResultStream.prototype._reconstructRoute = function () {
   while (previous && !loop) {
     path.unshift(previous);
     previous = this._minimumSpanningTree[previous.previous];
-    if (previous && minTime > previous.arrivalTime) {
+    if (previous && minTime >= previous.arrivalTime) {
       minTime = previous.arrivalTime;
     } else if (previous) {
       path.unshift(previous);


### PR DESCRIPTION
It is possible that a connection has the same departure- and arrival time.
This throws an "Infinite loop" error, but is not a cause of bad data.
